### PR TITLE
Setting up the latest github action to remove node12 usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the codebase
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # action/checkout@3.1.0
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup / Install Python
-        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # action/setup-python@4.3.0
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: '3.10.7'
           cache: 'pip' # caching pip dependencies
@@ -25,17 +25,17 @@ jobs:
         run: python download.py
 
       - name: Commit CDC Event Code changes
-        uses: EndBug/add-and-commit@d4d066316a2a85974a05efb42be78f897793c6d9 #EndBug/add-and-commit@9.1.0
+        uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b #v9.1.1
         with:
           author_name: Github Action Bot
           author_email: noreply@github.com
-          message: 'Nightly update of CDC event code changes'
+          message: 'Daily update of CDC event code changes'
           add: 'data/*'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 #ad-m/github-push-action@0.6.0
+        uses: ad-m/github-push-action@4dcce6dea3e3c8187237fc86b7dfdc93e5aaae58 #v0.6.0 + latest changes (Oct 11 2022)
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
- Updating github action to remove warning error of node12 usage.